### PR TITLE
Pin info_txt to a fixed height so only the input textbox height stretches on node resize

### DIFF
--- a/ui/extension.js
+++ b/ui/extension.js
@@ -120,6 +120,9 @@ app.registerExtension({
     // RANDOMIZE TEXT
     // ===================================
     if (nodeType?.comfyClass == "RandomizeTextWithCheck") {
+      const INFO_TEXT_HEIGHT = 60
+      const INFO_TEXT_MARGIN_TOP = "-4px"
+      
       const onNodeCreated = nodeType.prototype.onNodeCreated;
       nodeType.prototype.onNodeCreated = function () {
         const r = onNodeCreated ? onNodeCreated.apply(this, arguments) : undefined
@@ -128,6 +131,10 @@ app.registerExtension({
         infoTextWidget.element.readOnly = true
         infoTextWidget.value = ""
 
+        // Pin info_text to a fixed height so only the input widget stretches on resize
+        infoTextWidget.computeSize = () => [0, INFO_TEXT_HEIGHT]
+        infoTextWidget.element.style.marginTop = INFO_TEXT_MARGIN_TOP
+        
         if (textwWidget) {
           const callback = textwWidget.element.onkeyup
           textwWidget.element.onkeyup = (e) => {


### PR DESCRIPTION
This pins the height of info_txt to 60px, so when the node is extended, only the main text box is extended. 

Before:
<img width="461" height="562" alt="image" src="https://github.com/user-attachments/assets/d2027fcc-2306-4254-86fb-8e402572ee06" />

After:
<img width="468" height="567" alt="image" src="https://github.com/user-attachments/assets/4b7fe152-7443-468f-a6fe-352405d44bdb" />
